### PR TITLE
Rng mutation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -O0 -g
+CFLAGS = -O0 -g -DBIG
 
 all: discoal
 #

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -O3
+CFLAGS = -O0 -g
 
 all: discoal
 #

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -O0 -g -DBIG
+CFLAGS = -O3
 
 all: discoal
 #

--- a/discoal.h
+++ b/discoal.h
@@ -35,7 +35,7 @@ typedef struct rootedNode
 {
 	struct rootedNode *leftParent, *rightParent, *leftChild, *rightChild;
 	double time, branchLength, blProb;
-	float muts[MAXMUTS];
+	double muts[MAXMUTS];
 	#ifdef BIG
 	uint16_t ancSites[MAXSITES];
 	#else

--- a/discoalFunctions.c
+++ b/discoalFunctions.c
@@ -1875,7 +1875,7 @@ void dropMutations(){
 					else
 						mutSite = genunf((double)allNodes[i]->lLim / nSites, (double) allNodes[i]->rLim / nSites);
 				}
-				printf("new mut allele: %d mut: %f\n",i,mutSite);
+				//printf("new mut allele: %d mut: %f\n",i,mutSite);
 				addMutation(allNodes[i],mutSite);
 				m--;
 			}

--- a/discoalFunctions.c
+++ b/discoalFunctions.c
@@ -1875,7 +1875,7 @@ void dropMutations(){
 					else
 						mutSite = genunf((double)allNodes[i]->lLim / nSites, (double) allNodes[i]->rLim / nSites);
 				}
-				//printf("new mut allele: %d mut: %f\n",i,mutSite);
+				printf("new mut allele: %d mut: %f\n",i,mutSite);
 				addMutation(allNodes[i],mutSite);
 				m--;
 			}

--- a/discoalFunctions.h
+++ b/discoalFunctions.h
@@ -21,9 +21,12 @@ int nAncestorsHere(rootedNode *aNode, float site);
 
 int siteBetweenChunks(rootedNode *aNode, int xOverSite);
 void dropMutations();
-void addMutation(rootedNode *aNode, float site);
-int hasMutation(rootedNode *aNode, float site);
+void addMutation(rootedNode *aNode, double site);
+int hasMutation(rootedNode *aNode, double site);
 void makeGametesMS(int argc,const char *argv[]);
+void dropMutationsRecurse();
+void recurseTreePushMutation(rootedNode *aNode, float site);
+void errorCheckMutations();
 
 void mergePopns(int popnSrc, int popnDest);
 void admixPopns(int popnSrc, int popnDest1, int popnDest2, double admixProp);

--- a/discoal_multipop.c
+++ b/discoal_multipop.c
@@ -253,8 +253,10 @@ int main(int argc, const char * argv[]){
 			}
 			else{
 				//Hudson style output
+				//errorCheckMutations();
 				makeGametesMS(argc,argv);
 			}
+			//printf("rep: %d\n",i);
                         i++;
 		}
 		else{

--- a/discoal_multipop.c
+++ b/discoal_multipop.c
@@ -256,7 +256,7 @@ int main(int argc, const char * argv[]){
 				//errorCheckMutations();
 				makeGametesMS(argc,argv);
 			}
-			printf("rep: %d\n",i);
+			//printf("rep: %d\n",i);
                         i++;
 		}
 		else{
@@ -291,8 +291,14 @@ void getParameters(int argc,const char **argv){
 	if( argc < 3){
 		usage();
 	}
-	//locusNumber = atoi(argv[1]);
+
 	sampleSize = atoi(argv[1]);
+	if(sampleSize > 254){
+		#ifndef BIG
+		printf("Error: sampleSize > 254. recompile discoal and set the -DBIG flag\n");
+		exit(666);
+		#endif
+	}
 	sampleNumber = atoi(argv[2]);
 	nSites = atoi(argv[3]);
 	if(nSites>MAXSITES){

--- a/discoal_multipop.c
+++ b/discoal_multipop.c
@@ -256,7 +256,7 @@ int main(int argc, const char * argv[]){
 				//errorCheckMutations();
 				makeGametesMS(argc,argv);
 			}
-			//printf("rep: %d\n",i);
+			printf("rep: %d\n",i);
                         i++;
 		}
 		else{


### PR DESCRIPTION
floating point precision truncation was leading to collisions between mutation sites. This led to rare cases where a mutation was effectively "missed" and only visible because a no recombination simulation violated the four gamete test. 