### PR TITLE
Trajectory realloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -O2
+CFLAGS = -O2 -g
 
 all: discoal
 #

--- a/alleleTrajTest.c
+++ b/alleleTrajTest.c
@@ -9,6 +9,9 @@
 unsigned long devrand(void);
 #define MAXTRAJ 10000000
 
+// Have to init our extern global here, too
+size_t MAXTRAJSIZE = 10;
+
 void createTrajectory(int N,double alpha,double dt, double *currentTrajectory);
 
 int main (int argc, const char * argv[]) {

--- a/discoal.h
+++ b/discoal.h
@@ -4,6 +4,8 @@
 #ifndef __DISCOAL_GLOBALS__
 #define __DISCOAL_GLOBALS__
 
+#include <stdlib.h>
+
 /******************************************************************************/
 /* here are just some defines to allocate initial global arrays and stuff     */
 /* like that                                                                  */
@@ -116,9 +118,12 @@ double recurSweepRate;
 
 int EFFECTIVE_POPN_SIZE;
 
-#define TRAJSTEPSTART 5000000000
-long int  maxTrajSteps;
-float *currentTrajectory;
+/* This is the initial length of 
+ * a trajectory
+ */
+#define TRAJSTEPSTART 50
+extern size_t MAXTRAJSIZE;
+
 long int currentTrajectoryStep, totalTrajectorySteps;
 
 struct event events[MAXEVENTS];

--- a/discoalFunctions.h
+++ b/discoalFunctions.h
@@ -40,11 +40,11 @@ double sweepPhaseEventsGeneralPopNumber(int *bpArray, double startTime, double e
 			double *sizeRatio, char sweepMode,double f0, double uA);
 			
 			
-double recurrentSweepPhaseGeneralPopNumber(int *bpArray,double startTime, double endTime, double *finalFreq, double alpha, char sweepMode, double *sizeRatio);
+double recurrentSweepPhaseGeneralPopNumber(float * currentTrajectory, int *bpArray,double startTime, double endTime, double *finalFreq, double alpha, char sweepMode, double *sizeRatio);
 		
-double proposeTrajectory(int currentEventNumber, float *currentTrajectory, double *sizeRatio, char sweepMode, \
+double proposeTrajectory(int currentEventNumber, float **currentTrajectory, double *sizeRatio, char sweepMode, \
 	double initialFreq, double *finalFreq, double alpha, double f0, double currentTime);
-double sweepPhaseEventsConditionalTrajectory(int *bpArray, double startTime, double endTime, double sweepSite,\
+double sweepPhaseEventsConditionalTrajectory(float * currentTrajectory, int *bpArray, double startTime, double endTime, double sweepSite,\
 	double initialFreq, double *finalFreq, int *stillSweeping, double alpha,\
 	double *sizeRatio, char sweepMode,double f0, double uA);
 

--- a/discoal_multipop.c
+++ b/discoal_multipop.c
@@ -55,7 +55,6 @@ int main(int argc, const char * argv[]){
         totalSimCount = 0;
 
 	float * currentTrajectory = (float*)malloc(sizeof(float) * MAXTRAJSIZE);
-    fprintf(stderr,"%ld\n",&currentTrajectory);
 	assert(currentTrajectory);
 
 	while(i < sampleNumber){

--- a/discoal_multipop.c
+++ b/discoal_multipop.c
@@ -21,7 +21,7 @@
 #include "discoalFunctions.h"
 #include "alleleTraj.h"
 
-
+size_t MAXTRAJSIZE=TRAJSTEPSTART;
 
 int locusNumber; 
 int leftRhoFlag=0;
@@ -53,7 +53,9 @@ int main(int argc, const char * argv[]){
 	
 	i = 0;
         totalSimCount = 0;
-	currentTrajectory = malloc(sizeof(float) * TRAJSTEPSTART);
+
+	float * currentTrajectory = (float*)malloc(sizeof(float) * MAXTRAJSIZE);
+    fprintf(stderr,"%ld\n",&currentTrajectory);
 	assert(currentTrajectory);
 
 	while(i < sampleNumber){
@@ -62,7 +64,6 @@ int main(int argc, const char * argv[]){
 		currentSize[0]=1.0;
 		currentFreq = 1.0 - (1.0 / (2.0 * N * currentSize[0])); //just to initialize the value
 //		printf("popnsize[0]:%d",popnSizes[0]);
-		maxTrajSteps = TRAJSTEPSTART;
 		
 		
 		
@@ -91,21 +92,21 @@ int main(int argc, const char * argv[]){
 						currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
+						currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory,&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
 					}
 				}
 				else{
 					if(recurSweepMode ==0){
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 					 		currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
                                                		currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 					 		currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
-                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
+                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory,&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
 					}
 				}
 			//	printf("pn0:%d pn1:%d alleleNumber: %d sp1: %d sp2: %d \n", popnSizes[0],popnSizes[1], alleleNumber,sweepPopnSizes[1],
@@ -123,13 +124,13 @@ int main(int argc, const char * argv[]){
 			//	printf("event%d currentTime: %f nextTime: %f popnSize: %f\n",j,currentTime,nextTime,currentSize);
 
 				//generate a proposed trajectory
-				probAccept = proposeTrajectory(currentEventNumber, currentTrajectory, currentSize, sweepMode, currentFreq, &currentFreq, alpha, f0, currentTime);
+				probAccept = proposeTrajectory(currentEventNumber, &currentTrajectory, currentSize, sweepMode, currentFreq, &currentFreq, alpha, f0, currentTime);
 				while(ranf()>probAccept){
-					probAccept = proposeTrajectory(currentEventNumber, currentTrajectory, currentSize, sweepMode, currentFreq, &currentFreq, alpha, f0, currentTime);
+					probAccept = proposeTrajectory(currentEventNumber, &currentTrajectory, currentSize, sweepMode, currentFreq, &currentFreq, alpha, f0, currentTime);
 					//printf("probAccept: %lf\n",probAccept);
 				}
 				
-				currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+				currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 					 currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 			//	printf("currentFreqAfter: %f alleleNumber:%d\n",currentFreq,alleleNumber);
 			//	printf("pn0:%d pn1:%d alleleNumber: %d sp1: %d sp2: %d \n", popnSizes[0],popnSizes[1], alleleNumber,sweepPopnSizes[1],
@@ -148,21 +149,21 @@ int main(int argc, const char * argv[]){
 						currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
+						currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory,&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
 					}
 				}
 				else{
 					if(recurSweepMode ==0){
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 						 	currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
                                         		currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 					 		currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
-                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
+                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory,&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode, currentSize);
 					}
 				}
 				break;
@@ -174,21 +175,21 @@ int main(int argc, const char * argv[]){
 						currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
+						currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory,&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
 					}
 				}
 				else{
 					if(recurSweepMode ==0){
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 						 	currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
 	                                        	currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 					 		currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
-                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
+                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory,&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
 					}
 				}
 				break;
@@ -200,21 +201,21 @@ int main(int argc, const char * argv[]){
 						currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
+						currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory,&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
 					}
 				}
 				else{
 					if(recurSweepMode ==0){
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 						 	currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
 	                                        	currentTime = neutralPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, currentSize);
 					}
 					else{
-						currentTime = sweepPhaseEventsConditionalTrajectory(&breakPoints[0], currentTime, nextTime, sweepSite, \
+						currentTime = sweepPhaseEventsConditionalTrajectory(currentTrajectory,&breakPoints[0], currentTime, nextTime, sweepSite, \
 					 		currentFreq, &currentFreq, &activeSweepFlag, alpha, currentSize, sweepMode, f0, uA);
 						if (currentTime < nextTime)
-                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(&breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
+                                               		currentTime = recurrentSweepPhaseGeneralPopNumber(currentTrajectory, &breakPoints[0], currentTime, nextTime, &currentFreq, alpha, sweepMode,currentSize);
 					}
 				}
 				break;
@@ -276,6 +277,7 @@ int main(int argc, const char * argv[]){
         {
             fprintf(stderr, "Needed run %d simulations to get %d with a recombination event within the specified bounds.\n", totalSimCount, i);
         }
+        assert(currentTrajectory!=NULL);
 	free(currentTrajectory);
 	free(currentSize);
 	return(0);


### PR DESCRIPTION
Skips the really big allocation of `currentTrajectory` in favor of `realloc`. 

Changes:
* `currentTrajectory` is no longer global.  This was not required, but it makes it more obvious that the variable is owned by main.
* `proposeTrajectory` now takes a pointer to `currentTrajectory`, e.g. `float **`.  This change is required so that `realloc` events are propagated back to the caller.  The more idiomatic approach would be to have this function return the new pointer, but it already has a return value.
* `MAXTRAJSIZE` is a global `size_t`, defined as `extern` in `discoal.h` and initialized in `discoal_multipop.c`.  This variable is used to track the allocation size.
* Error handling is done via `exit` rather than `assert`, which would normally be disabled.

Note that `MAXTRAJSIZE` is set too small.  This was intentional, in order to stress test the realloc code.

I also thing I added -g to the Makefile as I was tracking down a double free issue for a bit there...